### PR TITLE
Refactor correlation causation ids

### DIFF
--- a/chocs_middleware/trace/logger.py
+++ b/chocs_middleware/trace/logger.py
@@ -81,7 +81,7 @@ class JsonFormatter(logging.Formatter):
             return record.msg
 
         if record.levelname != "DEBUG":
-            return str(record.msg)
+            return repr(record.msg)
 
         return record.msg
 

--- a/chocs_middleware/trace/logger.py
+++ b/chocs_middleware/trace/logger.py
@@ -68,7 +68,9 @@ class JsonEncoder(json.JSONEncoder):
 
 
 class JsonFormatter(logging.Formatter):
-    def __init__(self, json_encoder: json.JSONEncoder = JsonEncoder(), message_format: str = "[{level}] {timestamp} {msg}"):
+    def __init__(
+        self, json_encoder: json.JSONEncoder = JsonEncoder(), message_format: str = "[{level}] {timestamp} {msg}"
+    ):
         self.json_encoder = json_encoder
         self.message_format = message_format
         super(JsonFormatter, self).__init__()

--- a/chocs_middleware/trace/logger.py
+++ b/chocs_middleware/trace/logger.py
@@ -3,6 +3,7 @@ import logging
 import traceback
 from dataclasses import is_dataclass, asdict
 from datetime import date, datetime, time
+from decimal import Decimal
 from inspect import istraceback
 from typing import Dict, Optional, IO, Union, Any, List
 
@@ -74,13 +75,11 @@ class JsonFormatter(logging.Formatter):
 
     @staticmethod
     def get_message(record: logging.LogRecord) -> Any:
-        if isinstance(record.msg, str):
+        if isinstance(record.msg, (str, float, int, bool, Decimal, type(None))):
             return record.msg
 
         if record.levelname != "DEBUG":
-            msg = f"Dumping objects is prohibited at `{record.levelname}` log level."
-            record.levelname = "ERROR"
-            return msg
+            return str(record.msg)
 
         return record.msg
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "chocs_middleware.trace"
-version = "0.3.1"
+version = "0.4.0"
 description = "Http tracing middleware for chocs library."
 authors = ["Dawid Kraczkowski <dawid.kraczkowski@gmail.com>"]
 license = "MIT"

--- a/tests/trace/test_logger.py
+++ b/tests/trace/test_logger.py
@@ -133,7 +133,7 @@ def test_can_log_a_dict() -> None:
     assert log["log_message"] == {"test": "ok"}
 
 
-def test_fail_log_a_dict_in_non_debug_level() -> None:
+def test_log_a_dict_in_non_debug_level_as_string() -> None:
     # given
     logger_stream = StringIO()
     logger = Logger.get("test_cannot_log_a_dict", log_stream=logger_stream)
@@ -147,8 +147,8 @@ def test_fail_log_a_dict_in_non_debug_level() -> None:
     json_payload = record[record.find('\t'):]
     log = json.loads(json_payload)
 
-    assert log["level"] == "ERROR"
-    assert log["log_message"] != {"test": "ok"}
+    assert log["level"] == "INFO"
+    assert log["log_message"] == str({"test": "ok"})
 
 
 def test_can_retrieve_same_logger_multiple_times() -> None:

--- a/tests/trace/test_middleware.py
+++ b/tests/trace/test_middleware.py
@@ -19,7 +19,6 @@ def test_can_support_requests_lib() -> None:
 
         assert "x-correlation-id" in request.headers
         assert "x-causation-id" in request.headers
-        assert "x-request-id" in request.headers
 
         return "ok"
 
@@ -43,7 +42,6 @@ def urllib_support_mock(*args, **kwargs):
     headers = kwargs["headers"]
     assert "x-correlation-id" in headers
     assert "x-causation-id" in headers
-    assert "x-request-id" in headers
 
     return urllib3.HTTPResponse("ok")
 
@@ -80,10 +78,8 @@ def test_can_use_prefix_for_id() -> None:
 
         assert "x-correlation-id" in request.headers
         assert "x-causation-id" in request.headers
-        assert "x-request-id" in request.headers
         assert request.headers.get("x-correlation-id")[0:13] == "service-name-"
         assert request.headers.get("x-causation-id")[0:13] == "service-name-"
-        assert request.headers.get("x-request-id")[0:13] == "service-name-"
 
         return "ok"
 


### PR DESCRIPTION
**This PR fixes the following issues:** 

- confusion around `request-id`, `correlation-id` and `causation id`. With the change only `causation-id` and `correlation-id` are passed to requests made by application
- logging.~error is now not causing breakage when object is being passed to other level than debug, but instead is converted to a string representation.
- x-correlation-id, x-causation-id and x-request id are now at the top level of the structured log format 