### PR TITLE
Added support for special tags which can be placed at root level

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "chocs_middleware.trace"
-version = "0.4.0"
+version = "0.4.1"
 description = "Http tracing middleware for chocs library."
 authors = ["Dawid Kraczkowski <dawid.kraczkowski@gmail.com>"]
 license = "MIT"

--- a/tests/trace/test_logger.py
+++ b/tests/trace/test_logger.py
@@ -107,13 +107,13 @@ def test_can_attach_tags() -> None:
         log = json.loads(json_payload)
 
         assert "tags" in log
-        assert "x-request-id" in log["tags"]
-        assert "x-causation-id" in log["tags"]
-        assert "x-correlation-id" in log["tags"]
+        assert "x-request-id" in log
+        assert "x-causation-id" in log
+        assert "x-correlation-id" in log
 
-        assert log["tags"]["x-request-id"] == "req-1"
-        assert log["tags"]["x-causation-id"] == "caus-2"
-        assert log["tags"]["x-correlation-id"] == "correl-3"
+        assert log["x-request-id"] == "req-1"
+        assert log["x-causation-id"] == "caus-2"
+        assert log["x-correlation-id"] == "correl-3"
 
 
 def test_can_log_a_dict() -> None:


### PR DESCRIPTION
This PR adds ability to have special tags that are visible at the top level of the structured logging. 
By default `x-request-id`, `x-correlation-id` and `x-causation-id` are defined as root tags.