### PR TITLE
Change the default logger behavior to adjust to the majority of APMs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "chocs_middleware.trace"
-version = "0.4.2"
+version = "0.4.3"
 description = "Http tracing middleware for chocs library."
 authors = ["Dawid Kraczkowski <dawid.kraczkowski@gmail.com>"]
 license = "MIT"


### PR DESCRIPTION
Majority of APMs like: DataDog - they expect "message" property not "log_message" so I'm proposing to change it.

Secondly, if using string prefix then for exmaple DataDog with a default configuration has a problem with parsing values, for exmaple tags are not parsed as "event attributes" but all is displayed as a raw string. If we do not log the string prefix then every property will be tagged correctly.